### PR TITLE
Fix backup path detection in backupview

### DIFF
--- a/utils/backupview/clickhouse_backupview.py
+++ b/utils/backupview/clickhouse_backupview.py
@@ -747,7 +747,7 @@ class Backup:
         paths = []
         if self.dir_exists(f"/shards/{shard}/replicas/{replica}/metadata/"):
             paths.append(f"/shards/{shard}/replicas/{replica}/")
-        if self.dir_exists(f"/shards/{shard}metadata/"):
+        if self.dir_exists(f"/shards/{shard}/metadata/"):
             paths.append(f"/shards/{shard}/")
         if self.dir_exists(f"/replicas/{replica}/metadata/"):
             paths.append(f"/replicas/{replica}/")


### PR DESCRIPTION
## Notes
- installed `boto3` to run tests

## Summary
- fix incorrect shards metadata path in `clickhouse_backupview.py`

## Testing
- `pytest -q utils/backupview/test/test_backupview.py`

------
https://chatgpt.com/codex/tasks/task_e_68575e5a89588328ae1f3ff812fd0363